### PR TITLE
Version 5.44.0

### DIFF
--- a/mapkit/mapkit.Directions.d.ts
+++ b/mapkit/mapkit.Directions.d.ts
@@ -80,6 +80,9 @@ declare namespace mapkit {
      * routes when they are available.
      */
     requestsAlternateRoutes?: boolean;
+
+    arrivalDate?: Date;
+    departureDate?: Date;
   }
 
   /**

--- a/mapkit/mapkit.GeoJSON.d.ts
+++ b/mapkit/mapkit.GeoJSON.d.ts
@@ -30,7 +30,7 @@ declare namespace mapkit {
      * @param geoJSON The original GeoJSON object for this feature.
      */
     itemForFeature?(
-      item: mapkit.Annotation | mapkit.Overlay | null,
+      item: mapkit.Annotation | mapkit.Overlay | mapkit.ItemCollection | null,
       geoJSON: object,
     ): mapkit.Annotation | mapkit.Overlay | Array<mapkit.Annotation | mapkit.Overlay>;
     /**

--- a/mapkit/mapkit.Geocoder.d.ts
+++ b/mapkit/mapkit.Geocoder.d.ts
@@ -123,5 +123,18 @@ declare namespace mapkit {
      * The country code associated with the place.
      */
     countryCode: string;
+
+    administrativeArea: string | undefined;
+    administrativeAreaCode: string | undefined;
+    areasOfInterest: string[] | undefined;
+    country: string | undefined;
+    dependentLocalities: string[] | undefined;
+    fullThoroughfare: string | undefined;
+    locality: string | undefined;
+    pointOfInterestCategory: PointOfInterestCategory;
+    postCode: string | undefined;
+    subLocality: string | undefined;
+    subThoroughfare: string | undefined;
+    thoroughfare: string | undefined;
   }
 }

--- a/mapkit/mapkit.Map.d.ts
+++ b/mapkit/mapkit.Map.d.ts
@@ -596,56 +596,57 @@ declare namespace mapkit {
     maxCameraDistance: number;
   }
 
-  interface PointOfInterestFilter {
-    excludesCategory(category: PointOfInterestCategory): boolean;
-    excluding(categoryList: PointOfInterestCategory[]): PointOfInterestFilter;
-    includesCategory(category: PointOfInterestCategory): boolean;
-    including(categoryList: PointOfInterestCategory[]): PointOfInterestFilter;
+  class PointOfInterestFilter {
+    private constructor();
+    static excludesCategory(category: PointOfInterestCategory): boolean;
+    static excluding(categoryList: PointOfInterestCategory[]): PointOfInterestFilter;
+    static includesCategory(category: PointOfInterestCategory): boolean;
+    static including(categoryList: PointOfInterestCategory[]): PointOfInterestFilter;
 
     filterExcludingAllCategories: PointOfInterestFilter;
     filterIncludingAllCategories: PointOfInterestFilter;
   }
 
   interface PointOfInterestCategory {
-    Airport: string;
-    AmusementPark: string;
-    Aquarium: string;
-    ATM: string;
-    Bakery: string;
-    Bank: string;
-    Beach: string;
-    Brewery: string;
-    Cafe: string;
-    Campground: string;
-    CarRental: string;
-    EVCharger: string;
-    FireStation: string;
-    FitnessCenter: string;
-    FoodMarket: string;
-    GasStation: string;
-    Hospital: string;
-    Hotel: string;
-    Laundry: string;
-    Library: string;
-    Marina: string;
-    MovieTheater: string;
-    Museum: string;
-    NationalPark: string;
-    Nightlife: string;
-    Park: string;
-    Parking: string;
-    Pharmacy: string;
-    Police: string;
-    PostOffice: string;
-    PublicTransport: string;
-    Restaurant: string;
-    Restroom: string;
-    School: string;
-    Stadium: string;
-    Store: string;
-    Theater: string;
-    University: string;
-    Winery: string;
-    Zoo: string;
+    readonly Airport: string;
+    readonly AmusementPark: string;
+    readonly Aquarium: string;
+    readonly ATM: string;
+    readonly Bakery: string;
+    readonly Bank: string;
+    readonly Beach: string;
+    readonly Brewery: string;
+    readonly Cafe: string;
+    readonly Campground: string;
+    readonly CarRental: string;
+    readonly EVCharger: string;
+    readonly FireStation: string;
+    readonly FitnessCenter: string;
+    readonly FoodMarket: string;
+    readonly GasStation: string;
+    readonly Hospital: string;
+    readonly Hotel: string;
+    readonly Laundry: string;
+    readonly Library: string;
+    readonly Marina: string;
+    readonly MovieTheater: string;
+    readonly Museum: string;
+    readonly NationalPark: string;
+    readonly Nightlife: string;
+    readonly Park: string;
+    readonly Parking: string;
+    readonly Pharmacy: string;
+    readonly Police: string;
+    readonly PostOffice: string;
+    readonly PublicTransport: string;
+    readonly Restaurant: string;
+    readonly Restroom: string;
+    readonly School: string;
+    readonly Stadium: string;
+    readonly Store: string;
+    readonly Theater: string;
+    readonly University: string;
+    readonly Winery: string;
+    readonly Zoo: string;
   }
 }

--- a/mapkit/mapkit.Map.d.ts
+++ b/mapkit/mapkit.Map.d.ts
@@ -106,6 +106,33 @@ declare namespace mapkit {
      * Changes the map's visible map rectangle to the specified map rectangle.
      */
     setVisibleMapRectAnimated(mapRect: mapkit.MapRect, animate?: boolean): this;
+    /**
+     * Sets a constraint for the center of the map.
+     */
+    cameraBoundary: CameraBoundaryDescription;
+    /**
+     * Changes the map's camera boundary with an animated transition.
+     */
+    setCameraBoundaryAnimated(
+      coordinateRegion: CoordinateRegion | MapRect,
+      animate?: boolean,
+    ): this;
+    /**
+     * Sets the altitude of the camera above the center of the map.
+     */
+    cameraDistance: number;
+    /**
+     * Changes the map's camera distance with an animated transition.
+     */
+    setCameraDistanceAnimated(distance: number, animate?: boolean): this;
+    /**
+     * Sets the minimum and maximum distance of the camera from the map center.
+     */
+    cameraZoomRange: CameraZoomRange;
+    /**
+     * Changes the map's camera zoom range with an animated transition.
+     */
+    setCameraZoomRangeAnimated(cameraZoomRange: CameraZoomRange, animate?: boolean): this;
 
     // Configuring the Map's Appearance
 
@@ -449,6 +476,8 @@ declare namespace mapkit {
      * A Boolean value that determines whether the user location control is visible.
      */
     showsUserLocationControl?: boolean;
+
+    pointOfInterestFilter?: mapkit.PointOfInterestFilter;
   }
 
   /**
@@ -506,5 +535,117 @@ declare namespace mapkit {
      * Spacing that is added around the computed map region when showing items.
      */
     minimumSpan?: mapkit.CoordinateSpan;
+  }
+
+  /**
+   * An object literal containing at least one property defining an area on the map.
+   */
+  interface CameraBoundaryDescription {
+   /**
+    * A rectangular area on a two-dimensional map projection.
+    */
+    mapRect: mapkit.MapRect;
+   /**
+    * A rectangular area on a map, defined by coordinates of the rectangle's
+    * northeast and southwest corners.
+    */
+    region: mapkit.CoordinateRegion;
+  }
+
+  /**
+   * A minimum and maximum camera distance as meters from the center of the map.
+   */
+  class CameraZoomRange {
+    /**
+     * Describes the minimum and maximum camera distance in meters.
+     *
+     * @parent parent A DOM element or the ID of a DOM element to use as this
+     * map's container.
+     * @param options An object that contains options for initializing a map's
+     * features.
+     */
+    constructor(
+      minCameraDistance: CameraZoomRangeConstructorOptions | number,
+      maxCameraDistance?: number,
+    );
+    /**
+     * The minimum allowed distance of the camera from the center of the map in
+     * meters.
+     */
+    minCameraDistance: number;
+    /**
+     * The maximum allowed distance of the camera from the center of the map in
+     * meters.
+     */
+    maxCameraDistance: number;
+  }
+
+  /**
+   * Initialization options for the camera zoom range.
+   */
+  interface CameraZoomRangeConstructorOptions {
+    /**
+     * The minimum allowed distance of the camera from the center of the map in
+     * meters.
+     */
+    minCameraDistance: number;
+    /**
+     * The maximum allowed distance of the camera from the center of the map in
+     * meters.
+     */
+    maxCameraDistance: number;
+  }
+
+  interface PointOfInterestFilter {
+    excludesCategory(category: PointOfInterestCategory): boolean;
+    excluding(categoryList: PointOfInterestCategory[]): PointOfInterestFilter;
+    includesCategory(category: PointOfInterestCategory): boolean;
+    including(categoryList: PointOfInterestCategory[]): PointOfInterestFilter;
+
+    filterExcludingAllCategories: PointOfInterestFilter;
+    filterIncludingAllCategories: PointOfInterestFilter;
+  }
+
+  interface PointOfInterestCategory {
+    Airport: string;
+    AmusementPark: string;
+    Aquarium: string;
+    ATM: string;
+    Bakery: string;
+    Bank: string;
+    Beach: string;
+    Brewery: string;
+    Cafe: string;
+    Campground: string;
+    CarRental: string;
+    EVCharger: string;
+    FireStation: string;
+    FitnessCenter: string;
+    FoodMarket: string;
+    GasStation: string;
+    Hospital: string;
+    Hotel: string;
+    Laundry: string;
+    Library: string;
+    Marina: string;
+    MovieTheater: string;
+    Museum: string;
+    NationalPark: string;
+    Nightlife: string;
+    Park: string;
+    Parking: string;
+    Pharmacy: string;
+    Police: string;
+    PostOffice: string;
+    PublicTransport: string;
+    Restaurant: string;
+    Restroom: string;
+    School: string;
+    Stadium: string;
+    Store: string;
+    Theater: string;
+    University: string;
+    Winery: string;
+    Zoo: string;
   }
 }

--- a/mapkit/mapkit.Search.d.ts
+++ b/mapkit/mapkit.Search.d.ts
@@ -39,7 +39,7 @@ declare namespace mapkit {
     autocomplete(
       query: string,
       callback: SearchDelegate | AutocompleteSearchCallback,
-      options?: SearchOptions,
+      options?: SearchAutocompleteOptions,
     ): void;
     /**
      * Cancels a search request using its request ID.
@@ -71,6 +71,11 @@ declare namespace mapkit {
      * A map region that provides a hint for the geographic area to search.
      */
     region?: mapkit.CoordinateRegion;
+
+    includeAddresses?: boolean;
+    includePointsOfInterest?: boolean;
+    includeQueries?: boolean;
+    pointOfInterestFilter?: PointOfInterestFilter;
   }
 
   type SearchCallback<Q> = (
@@ -137,6 +142,10 @@ declare namespace mapkit {
      * A map region that provides a hint for the geographic area to search.
      */
     region: mapkit.CoordinateRegion;
+
+    includeAddresses: boolean;
+    includePointsOfInterest: boolean;
+    pointOfInterestFilter: boolean;
   }
 
   /**
@@ -184,5 +193,15 @@ declare namespace mapkit {
      * The coordinate of the result, provided when it corresponds to a single place.
      */
     coordinate: mapkit.Coordinate;
+  }
+
+  interface SearchAutocompleteOptions {
+    language: string;
+    coordinate: mapkit.Coordinate;
+    region: mapkit.CoordinateRegion;
+    includeAddresses: boolean;
+    includePointsOfInterest: boolean;
+    includeQueries: boolean;
+    pointOfInterestFilter: mapkit.PointOfInterestFilter;
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapkit-typescript",
-  "version": "5.18.2",
+  "version": "5.44.0",
   "description": "Typescript type definitions for MapKit JS",
   "repository": "wsmd/mapkit-typescript",
   "types": "./mapkit/index.d.ts",

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,7 @@
     "exclude": ["test/**", "node_modules/**"]
   },
   "rules": {
+    "array-type": [true, "array-simple"],
     "interface-name": [true, "never-prefix"],
     "max-classes-per-file": false,
     "max-line-length": [true, 100],


### PR DESCRIPTION
Updated with changes for v5.44.0.

I'm not very experienced with typescript and typings, so I essentially copied how the other typings looked. `npm run test` and `npm run lint` run without errors.

I had a few issues, where I'm curios how you'd have done that:
- many methods/properties had no description available in Apple's docs, so I didn't know what to add here. Would you prefer to make them up or just leave them empty?
- `setCameraBoundaryAnimated` accepts two different types as its first parameter, but according to Apple's docs they use a different parameter name depending on the type (`coordinateRegion: mapkit.CoordinateRegion | mapRect: mapkit.MapRect`), which (as far as I understand – please correct me if I'm wrong) is not supported in typescript. I tried overloading the method, i.e. adding it twice (one for each parameter name), but the linter insisted on combining them, and I wasn't sure if silencing the linter is more desirable, so I changed it.
See [the docs here](https://developer.apple.com/documentation/mapkitjs/mapkit/map/3257751-setcameraboundaryanimated) and the [line in my code here](https://github.com/wsmd/mapkit-typescript/compare/master...0bmxa:v5.44.0#diff-dd47fe3255817ed8742f9d65c87b6f7aR117).
- I also noticed, several properties being marked as optional. I also did that where test would fail because of them not being optional, but I didn't really understand where that is appropriate. Should that be done everywhere?

I'm happy about feedback, or also happy to change anything, just let me know!